### PR TITLE
Fix: Remove incorrect @vercel/vite builder from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,14 +2,6 @@
   "version": 2,
   "builds": [
     {
-      "src": "vite.config.ts",
-      "use": "@vercel/vite",
-      "config": {
-        "project": ".",
-        "outputDirectory": "dist"
-      }
-    },
-    {
       "src": "server/server.js",
       "use": "@vercel/node"
     }


### PR DESCRIPTION
Removes the explicit Vite build configuration from `vercel.json`. Vercel should automatically detect and build the Vite frontend. This resolves the error: 'The package `@vercel/vite` is not published on the npm registry'.