### PR TITLE
feat: Add placeholder APIs for various integrations

### DIFF
--- a/server/src/controllers/externalAssessmentController.js
+++ b/server/src/controllers/externalAssessmentController.js
@@ -1,0 +1,38 @@
+const asyncHandler = require('express-async-handler');
+
+// @desc    Configure an external assessment tool
+// @route   POST /api/v1/integrations/assessment/configure
+// @access  Private (Admin)
+exports.configureAssessmentTool = asyncHandler(async (req, res) => {
+  const { toolName, apiKey, apiSecret, settings } = req.body; // Example parameters
+  // Logic to save or update configuration for an external assessment tool.
+  res.status(200).json({ message: 'Configure external assessment tool endpoint hit. Logic pending.', config: req.body });
+});
+
+// @desc    Trigger or initiate an assessment in an external tool
+// @route   POST /api/v1/integrations/assessment/trigger
+// @access  Private (Instructor, Admin, or Student for self-assessment)
+exports.triggerAssessment = asyncHandler(async (req, res) => {
+  const { assessmentId, userId, courseId } = req.body; // Example parameters
+  // Logic to initiate an assessment (e.g., create an attempt URL, notify the tool).
+  res.status(200).json({ message: 'Trigger assessment endpoint hit. Logic pending.', details: req.body });
+});
+
+// @desc    Get results from an external assessment tool
+// @route   GET /api/v1/integrations/assessment/results/:attemptId
+// @access  Private (Student for own results, Instructor, Admin)
+exports.getAssessmentResults = asyncHandler(async (req, res) => {
+  const { attemptId } = req.params;
+  // Logic to fetch assessment results from the external tool using the attemptId or other identifiers.
+  res.status(200).json({ message: `Get assessment results for attempt ${attemptId} endpoint hit. Logic pending.` });
+});
+
+// @desc    Handle a webhook from an External Assessment Tool (e.g., assessment completed)
+// @route   POST /api/v1/integrations/assessment/webhook
+// @access  Public (secured via signature/token)
+exports.handleAssessmentWebhook = asyncHandler(async (req, res) => {
+    // Logic to verify and process webhook from an assessment tool
+    // (e.g., results ready, grade update)
+    console.log('External Assessment Tool webhook received:', req.body);
+    res.status(200).json({ message: 'External Assessment Tool webhook received. Logic pending.' });
+});

--- a/server/src/controllers/lmsIntegrationController.js
+++ b/server/src/controllers/lmsIntegrationController.js
@@ -1,0 +1,41 @@
+const asyncHandler = require('express-async-handler');
+
+// @desc    Get LMS connection status or configuration
+// @route   GET /api/v1/integrations/lms/status
+// @access  Private (Admin)
+exports.getLmsStatus = asyncHandler(async (req, res) => {
+  res.status(200).json({ message: 'LMS status endpoint hit. Integration logic pending.' });
+});
+
+// @desc    Synchronize courses to the LMS
+// @route   POST /api/v1/integrations/lms/sync/courses
+// @access  Private (Admin)
+exports.syncCoursesToLms = asyncHandler(async (req, res) => {
+  // In a real implementation, this would involve:
+  // 1. Fetching courses from the local database.
+  // 2. Transforming data to the LMS format.
+  // 3. Calling the LMS API to create/update courses.
+  res.status(200).json({ message: 'LMS course sync endpoint hit. Integration logic pending.' });
+});
+
+// @desc    Pull grades from the LMS
+// @route   GET /api/v1/integrations/lms/grades
+// @access  Private (Admin)
+exports.pullGradesFromLms = asyncHandler(async (req, res) => {
+  // In a real implementation, this would involve:
+  // 1. Calling the LMS API to fetch grades.
+  // 2. Matching LMS users/courses to local users/courses.
+  // 3. Updating local grade records.
+  res.status(200).json({ message: 'LMS grades pull endpoint hit. Integration logic pending.' });
+});
+
+// @desc    Handle a webhook notification from LMS
+// @route   POST /api/v1/integrations/lms/webhook
+// @access  Public (but secured, e.g. with a secret token checked in implementation)
+exports.handleLmsWebhook = asyncHandler(async (req, res) => {
+    // In a real implementation, this would involve:
+    // 1. Verifying the webhook signature/secret.
+    // 2. Processing the event data from the LMS (e.g., enrollment update, course completion).
+    console.log('LMS Webhook received:', req.body);
+    res.status(200).json({ message: 'LMS webhook received. Processing logic pending.' });
+});

--- a/server/src/controllers/thirdPartyToolController.js
+++ b/server/src/controllers/thirdPartyToolController.js
@@ -1,0 +1,38 @@
+const asyncHandler = require('express-async-handler');
+
+// @desc    List configured third-party tools
+// @route   GET /api/v1/integrations/tools
+// @access  Private (Admin)
+exports.listConfiguredTools = asyncHandler(async (req, res) => {
+  // Logic to fetch and list configured tools from a database or config file
+  res.status(200).json({ message: 'List configured tools endpoint hit. Logic pending.' });
+});
+
+// @desc    Configure a specific third-party tool
+// @route   POST /api/v1/integrations/tools/:toolId/configure
+// @access  Private (Admin)
+exports.configureTool = asyncHandler(async (req, res) => {
+  const { toolId } = req.params;
+  const { apiKey, apiSecret, settings } = req.body; // Example configuration parameters
+  // Logic to save or update the configuration for toolId
+  res.status(200).json({ message: `Configure tool ${toolId} endpoint hit. Logic pending.`, data: { toolId, apiKey, settings } });
+});
+
+// @desc    Get data or status from a specific third-party tool
+// @route   GET /api/v1/integrations/tools/:toolId/data
+// @access  Private (Admin or specific roles depending on the tool)
+exports.getToolData = asyncHandler(async (req, res) => {
+  const { toolId } = req.params;
+  // Logic to interact with the third-party tool's API
+  res.status(200).json({ message: `Get data for tool ${toolId} endpoint hit. Logic pending.` });
+});
+
+// @desc    Handle a webhook from a third-party tool
+// @route   POST /api/v1/integrations/tools/:toolId/webhook
+// @access  Public (secured via signature/token)
+exports.handleToolWebhook = asyncHandler(async (req, res) => {
+    const { toolId } = req.params;
+    // Logic to verify and process webhook from toolId
+    console.log(`Webhook for tool ${toolId} received:`, req.body);
+    res.status(200).json({ message: `Webhook for tool ${toolId} received. Logic pending.` });
+});

--- a/server/src/controllers/videoConferencingController.js
+++ b/server/src/controllers/videoConferencingController.js
@@ -1,0 +1,38 @@
+const asyncHandler = require('express-async-handler');
+
+// @desc    Create a new video conference meeting
+// @route   POST /api/v1/integrations/video/meetings
+// @access  Private (Instructor, Admin)
+exports.createMeeting = asyncHandler(async (req, res) => {
+  const { topic, startTime, duration, agenda, participants } = req.body; // Example parameters
+  // Logic to interact with a video conferencing service API (e.g., Zoom, Microsoft Teams)
+  // to schedule a new meeting.
+  res.status(201).json({ message: 'Create video conference meeting endpoint hit. Logic pending.', meetingDetails: req.body });
+});
+
+// @desc    Get information about a specific video conference meeting
+// @route   GET /api/v1/integrations/video/meetings/:meetingId
+// @access  Private (Participants, Instructor, Admin)
+exports.getMeetingInfo = asyncHandler(async (req, res) => {
+  const { meetingId } = req.params;
+  // Logic to fetch meeting details from the video conferencing service.
+  res.status(200).json({ message: `Get info for meeting ${meetingId} endpoint hit. Logic pending.` });
+});
+
+// @desc    List recordings for meetings (e.g., associated with a course or user)
+// @route   GET /api/v1/integrations/video/recordings
+// @access  Private (Instructor, Admin, or enrolled students if applicable)
+exports.listRecordings = asyncHandler(async (req, res) => {
+  // Logic to list recordings. May require query parameters to filter by course, user, etc.
+  res.status(200).json({ message: 'List video conference recordings endpoint hit. Logic pending.' });
+});
+
+// @desc    Handle a webhook from a Video Conferencing provider
+// @route   POST /api/v1/integrations/video/webhook
+// @access  Public (secured via signature/token)
+exports.handleVideoConferenceWebhook = asyncHandler(async (req, res) => {
+    // Logic to verify and process webhook from a video conferencing provider
+    // (e.g., meeting started, meeting ended, recording ready)
+    console.log('Video conference webhook received:', req.body);
+    res.status(200).json({ message: 'Video conference webhook received. Logic pending.' });
+});

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -35,6 +35,8 @@ const feedbackRoutes = require('./routes/feedbackRoutes'); // Import feedback ro
 const forumPostRoutes = require('./routes/forumPostRoutes'); // Import forum post routes
 const badgeRoutes = require('./routes/badgeRoutes'); // Import badge routes
 const contentRoutes = require('./routes/contentRoutes'); // Import content routes
+const integrationRoutes = require('./routes/integrationRoutes'); // Import integration routes
+const integrationRoutes = require('./routes/integrationRoutes'); // Import integration routes
 
 // Mount Routers
 // Ensure your API base path is consistent. If it's /api/v1, it should be used here.
@@ -59,6 +61,7 @@ app.use('/api/v1/user-learning-paths', userLearningPathRoutes); // Mount user le
 app.use('/api/v1/feedback', feedbackRoutes); // Mount feedback routes
 app.use('/api/v1/forum-posts', forumPostRoutes); // Mount forum post routes
 app.use('/api/v1/badges', badgeRoutes); // Mount badge routes
+app.use('/api/v1/integrations', integrationRoutes); // Mount integration routes
 
 // Basic Route
 app.get('/', (req, res) => {

--- a/server/src/routes/calendarIntegrationRoutes.js
+++ b/server/src/routes/calendarIntegrationRoutes.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getCalendarEvents,
+  createCalendarEvent,
+  syncCalendar,
+  handleCalendarWebhook
+} = require('../controllers/calendarIntegrationController');
+const { protect, checkRole } = require('../middleware/authMiddleware'); // Assuming Admin for sync, user for own events
+
+// GET /api/v1/integrations/calendar/events
+// Users can get their own events. Admins could potentially access more (logic in controller).
+router.get(
+    '/events',
+    protect, // All logged-in users can try, controller can filter by user vs admin
+    getCalendarEvents
+);
+
+// POST /api/v1/integrations/calendar/events
+// Users can create events for themselves.
+router.post(
+    '/events',
+    protect,
+    createCalendarEvent
+);
+
+// POST /api/v1/integrations/calendar/sync
+// Typically an admin task, or a user managing their own sync settings.
+router.post(
+    '/sync',
+    protect,
+    checkRole(['Admin']), // Or could be user-specific if they manage their own sync
+    syncCalendar
+);
+
+// POST /api/v1/integrations/calendar/webhook
+router.post(
+    '/webhook',
+    handleCalendarWebhook // Security handled in controller
+);
+
+module.exports = router;

--- a/server/src/routes/externalAssessmentRoutes.js
+++ b/server/src/routes/externalAssessmentRoutes.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const router = express.Router();
+const {
+  configureAssessmentTool,
+  triggerAssessment,
+  getAssessmentResults,
+  handleAssessmentWebhook
+} = require('../controllers/externalAssessmentController');
+const { protect, checkRole } = require('../middleware/authMiddleware');
+
+// POST /api/v1/integrations/assessment/configure
+router.post(
+    '/configure',
+    protect,
+    checkRole(['Admin']),
+    configureAssessmentTool
+);
+
+// POST /api/v1/integrations/assessment/trigger
+router.post(
+    '/trigger',
+    protect,
+    // Allowing Instructors or Admins to trigger. Students might trigger specific types via other routes.
+    checkRole(['Instructor', 'Admin']),
+    triggerAssessment
+);
+
+// GET /api/v1/integrations/assessment/results/:attemptId
+router.get(
+    '/results/:attemptId',
+    protect, // Controller would handle if student can see own, or if instructor/admin
+    getAssessmentResults
+);
+
+// POST /api/v1/integrations/assessment/webhook
+router.post(
+    '/webhook',
+    handleAssessmentWebhook // Security handled in controller
+);
+
+module.exports = router;

--- a/server/src/routes/integrationRoutes.js
+++ b/server/src/routes/integrationRoutes.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = express.Router();
+
+const lmsIntegrationRoutes = require('./lmsIntegrationRoutes');
+const thirdPartyToolRoutes = require('./thirdPartyToolRoutes');
+const calendarIntegrationRoutes = require('./calendarIntegrationRoutes');
+const videoConferencingRoutes = require('./videoConferencingRoutes');
+const externalAssessmentRoutes = require('./externalAssessmentRoutes');
+
+// Mount sub-routers
+router.use('/lms', lmsIntegrationRoutes);
+router.use('/tools', thirdPartyToolRoutes);
+router.use('/calendar', calendarIntegrationRoutes);
+router.use('/video', videoConferencingRoutes);
+router.use('/assessment', externalAssessmentRoutes);
+
+router.get('/', (req, res) => {
+  res.status(200).json({ message: 'Integration API Base Route - All sub-integrations mounted.' });
+});
+
+module.exports = router;

--- a/server/src/routes/lmsIntegrationRoutes.js
+++ b/server/src/routes/lmsIntegrationRoutes.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getLmsStatus,
+  syncCoursesToLms,
+  pullGradesFromLms,
+  handleLmsWebhook
+} = require('../controllers/lmsIntegrationController');
+const { protect, checkRole } = require('../middleware/authMiddleware');
+
+// GET /api/v1/integrations/lms/status
+router.get(
+    '/status',
+    protect,
+    checkRole(['Admin']),
+    getLmsStatus
+);
+
+// POST /api/v1/integrations/lms/sync/courses
+router.post(
+    '/sync/courses',
+    protect,
+    checkRole(['Admin']),
+    syncCoursesToLms
+);
+
+// GET /api/v1/integrations/lms/grades
+router.get(
+    '/grades',
+    protect,
+    checkRole(['Admin']),
+    pullGradesFromLms
+);
+
+// POST /api/v1/integrations/lms/webhook
+// Webhooks are typically public but should have signature verification within the controller
+router.post(
+    '/webhook',
+    handleLmsWebhook // Specific security for webhooks (e.g. HMAC signature) handled in controller
+);
+
+module.exports = router;

--- a/server/src/routes/thirdPartyToolRoutes.js
+++ b/server/src/routes/thirdPartyToolRoutes.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const router = express.Router();
+const {
+  listConfiguredTools,
+  configureTool,
+  getToolData,
+  handleToolWebhook
+} = require('../controllers/thirdPartyToolController');
+const { protect, checkRole } = require('../middleware/authMiddleware');
+
+// GET /api/v1/integrations/tools
+router.get(
+    '/',
+    protect,
+    checkRole(['Admin']),
+    listConfiguredTools
+);
+
+// POST /api/v1/integrations/tools/:toolId/configure
+router.post(
+    '/:toolId/configure',
+    protect,
+    checkRole(['Admin']),
+    configureTool
+);
+
+// GET /api/v1/integrations/tools/:toolId/data
+router.get(
+    '/:toolId/data',
+    protect,
+    checkRole(['Admin']), // Or more specific roles if necessary
+    getToolData
+);
+
+// POST /api/v1/integrations/tools/:toolId/webhook
+router.post(
+    '/:toolId/webhook',
+    handleToolWebhook // Security handled in controller
+);
+
+module.exports = router;

--- a/server/src/routes/videoConferencingRoutes.js
+++ b/server/src/routes/videoConferencingRoutes.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const router = express.Router();
+const {
+  createMeeting,
+  getMeetingInfo,
+  listRecordings,
+  handleVideoConferenceWebhook
+} = require('../controllers/videoConferencingController');
+const { protect, checkRole } = require('../middleware/authMiddleware');
+
+// POST /api/v1/integrations/video/meetings
+router.post(
+    '/meetings',
+    protect,
+    checkRole(['Instructor', 'Admin']),
+    createMeeting
+);
+
+// GET /api/v1/integrations/video/meetings/:meetingId
+router.get(
+    '/meetings/:meetingId',
+    protect, // Further access control logic can be in the controller (e.g. participant check)
+    getMeetingInfo
+);
+
+// GET /api/v1/integrations/video/recordings
+router.get(
+    '/recordings',
+    protect, // Further access control logic can be in the controller
+    listRecordings
+);
+
+// POST /api/v1/integrations/video/webhook
+router.post(
+    '/webhook',
+    handleVideoConferenceWebhook // Security handled in controller
+);
+
+module.exports = router;


### PR DESCRIPTION
Adds the basic routing and controller structure for future integration with:
- LMS systems
- Third-party tools
- Calendar services
- Video conferencing platforms
- External assessment tools

Each API has placeholder endpoints and controllers returning a success or 'Not Implemented' message. Authentication and authorization middleware (Admin or specific roles) have been applied as appropriate for initial setup.

The main integration router is mounted at /api/v1/integrations.